### PR TITLE
Two improvements for md

### DIFF
--- a/scripts/boot-devfunctions.sh
+++ b/scripts/boot-devfunctions.sh
@@ -67,6 +67,7 @@ check_for_device() {
     fi
     if [ -n "$root" ]; then
         echo -n "Waiting for device $root to appear: "
+        let halftime=$timeout/2
         while [ $timeout -gt 0 ]; do
             if [ -e "$root" ]; then
                 udev_devn=$(devnumber $root)
@@ -101,6 +102,10 @@ check_for_device() {
             usleep 25000
             ((timeout % 40 == 1)) && echo -n "."
             let timeout--
+            if [ "$need_mdadm" = "1" -a "$timeout" -eq "$halftime" ] ; then
+                # time to start any newly-degraded md arrays
+                mdadm -IRs
+            fi
             # Recheck for LVM volumes
             if [ -n "$vg_root" -a -n "$vg_roots" ] ; then
                 vgscan

--- a/scripts/setup-udev.sh
+++ b/scripts/setup-udev.sh
@@ -78,7 +78,6 @@ for rule in \
     61-msft.rules \
     62-dm_linear.rules \
     64-device-mapper.rules \
-    64-md-raid.rules \
     79-kms.rules \
     80-drivers.rules; do
     if [ -f /usr/lib/udev/rules.d/$rule ]; then


### PR DESCRIPTION
1/ Don't install the udev rules file 64-md-raid.rules.
  It has been renamed to 2 different files, and the mdadm
  package installs it now.

2/ Run "mdadm -IRs" at half-time when waiting for the root
  device to appear.
  This will start any newly-degraded array (weren't degraded when
  machine was shut down).

Signed-off-by: NeilBrown neilb@suse.de
