### PR TITLE
Add missing PCI USB HCI modules (bnc#839071).

### DIFF
--- a/scripts/boot-usb.sh
+++ b/scripts/boot-usb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #%stage: device
-#%udevmodules: usbcore ohci_hcd uhci-hcd ehci_hcd xhci-hcd usbhid hid-logitech-dj hid-generic hid-holtek-kbd hid-lenovo-tpkbd hid-logitech-dj hid-ortek hid-roccat-arvo hid-roccat-isku hid-samsung hid-apple hid-belkin hid-cherry hid-ezkey hid-microsoft
+#%udevmodules: usbcore ohci_hcd uhci-hcd ehci_hcd xhci-hcd usbhid hid-logitech-dj hid-generic hid-holtek-kbd hid-lenovo-tpkbd hid-logitech-dj hid-ortek hid-roccat-arvo hid-roccat-isku hid-samsung hid-apple hid-belkin hid-cherry hid-ezkey hid-microsoft ehci-pci ohci-pci
 #%if: "$use_usb"
 #
 ##### usb module helper


### PR DESCRIPTION
USB keyboards weren't available on some systems due to missing PCI HCD
modules. This caused problems with e.g. LUKS encryption.

Signed-off-by: Jeff Mahoney jeffm@suse.com
