### PR TITLE
Update script/setup-done.sh to use pigz if installed

### DIFF
--- a/scripts/setup-done.sh
+++ b/scripts/setup-done.sh
@@ -4,7 +4,13 @@
 #%depends: progs sharedlibs
 #
 
-COMPRESS="gzip"
+# Use parallel compressing tool if installed
+if [ -x /usr/bin/pigz ];then
+    COMPRESS="pigz"
+else
+    COMPRESS="gzip"
+fi
+
 
 if [[ $(uname -m) =~ ppc ]]
 then


### PR DESCRIPTION
Use of pigz parallel tool if installed improving greatly initrd creation time especially on multi-core computers. Until we switch to a one time mkinitrd call during setup or usage, a lot of install time is used to create several time the initrd of the system. 
Using pigz creatly improve the creation time process.
# Example with gzip only

time mkinitrd

Kernel image:   /boot/vmlinuz-3.11.10-7-desktop
Initrd image:   /boot/initrd-3.11.10-7-desktop
Root device:    /dev/vg0/lvsuse (mounted on / as ext4)
Resume device:  /dev/vg0/lvswap
enabling LUKS support for /dev/disk/by-id/ata-Corsair_Force_GT_114882050000098800C7-part2 (cr_sda2)
Microcode: Adding Intel microcode 06-2a-07
modprobe: Module crct10dif_pclmul not found.
WARNING: no dependencies for kernel module 'crct10dif_pclmul' found.
Kernel Modules: thermal_sys thermal processor fan dm-mod dm-crypt dm-log dm-region-hash dm-mirror dm-snapshot scsi_dh scsi_dh_hp_sw scsi_dh_alua scsi_dh_rdac scsi_dh_emc xhci-hcd hid-logitech-dj hid-holtek-kbd hid-lenovo-tpkbd hid-ortek hid-roccat hid-roccat-common hid-roccat-arvo hid-roccat-isku hid-samsung ohci-pci linear arc4 sha256_generic cryptd crc32-pclmul crc32c-intel ghash-clmulni-intel aes-x86_64 glue_helper gf128mul lrw ablk_helper aesni-intel libcrc32c xor zlib_deflate raid6_pq btrfs
Features:       acpi dm intel_microcode block usb lvm2 luks btrfs resume.userspace resume.kernel

Kernel image:   /boot/vmlinuz-3.13.6-1.g4727218-desktop
Initrd image:   /boot/initrd-3.13.6-1.g4727218-desktop
KMS drivers:     nvidia
Root device:    /dev/vg0/lvsuse (mounted on / as ext4)
Resume device:  /dev/vg0/lvswap
enabling LUKS support for /dev/disk/by-id/ata-Corsair_Force_GT_114882050000098800C7-part2 (cr_sda2)
Microcode: Adding Intel microcode 06-2a-07
Kernel Modules: thermal_sys thermal processor fan dm-mod dm-crypt dm-log dm-region-hash dm-mirror dm-snapshot scsi_dh scsi_dh_hp_sw scsi_dh_alua scsi_dh_rdac scsi_dh_emc drm nvidia xhci-hcd hid-logitech-dj hid-holtek-kbd hid-lenovo-tpkbd hid-ortek hid-roccat hid-roccat-common hid-roccat-arvo hid-roccat-isku hid-samsung ohci-pci linear arc4 sha256_generic cryptd crct10dif-pclmul crc32-pclmul crc32c-intel ghash-clmulni-intel aes-x86_64 glue_helper gf128mul lrw ablk_helper aesni-intel libcrc32c xor raid6_pq btrfs
Features:       acpi dm intel_microcode kms block usb lvm2 luks btrfs resume.userspace resume.kernel

Kernel image:   /boot/vmlinuz-3.13.6-2.g0509ce5-desktop
Initrd image:   /boot/initrd-3.13.6-2.g0509ce5-desktop
KMS drivers:     nvidia
Root device:    /dev/vg0/lvsuse (mounted on / as ext4)
Resume device:  /dev/vg0/lvswap
enabling LUKS support for /dev/disk/by-id/ata-Corsair_Force_GT_114882050000098800C7-part2 (cr_sda2)
Microcode: Adding Intel microcode 06-2a-07
Kernel Modules: thermal_sys thermal processor fan dm-mod dm-crypt dm-log dm-region-hash dm-mirror dm-snapshot scsi_dh scsi_dh_hp_sw scsi_dh_alua scsi_dh_rdac scsi_dh_emc drm nvidia xhci-hcd hid-logitech-dj hid-holtek-kbd hid-lenovo-tpkbd hid-ortek hid-roccat hid-roccat-common hid-roccat-arvo hid-roccat-isku hid-samsung ohci-pci linear arc4 sha256_generic cryptd crct10dif-pclmul crc32-pclmul crc32c-intel ghash-clmulni-intel aes-x86_64 glue_helper gf128mul lrw ablk_helper aesni-intel libcrc32c xor raid6_pq btrfs
Features:       acpi dm intel_microcode kms block usb lvm2 luks btrfs resume.userspace resume.kernel

real    0m21.444s
user    0m14.628s
sys     0m2.092s
# Example with pigz on 8 core computer

time mkinitrd 

Kernel image:   /boot/vmlinuz-3.11.10-7-desktop
Initrd image:   /boot/initrd-3.11.10-7-desktop
Root device:    /dev/vg0/lvsuse (mounted on / as ext4)
Resume device:  /dev/vg0/lvswap
enabling LUKS support for /dev/disk/by-id/ata-Corsair_Force_GT_114882050000098800C7-part2 (cr_sda2)
Microcode: Adding Intel microcode 06-2a-07
modprobe: Module crct10dif_pclmul not found.
WARNING: no dependencies for kernel module 'crct10dif_pclmul' found.
Kernel Modules: thermal_sys thermal processor fan dm-mod dm-crypt dm-log dm-region-hash dm-mirror dm-snapshot scsi_dh scsi_dh_hp_sw scsi_dh_alua scsi_dh_rdac scsi_dh_emc xhci-hcd hid-logitech-dj hid-holtek-kbd hid-lenovo-tpkbd hid-ortek hid-roccat hid-roccat-common hid-roccat-arvo hid-roccat-isku hid-samsung ohci-pci linear arc4 sha256_generic cryptd crc32-pclmul crc32c-intel ghash-clmulni-intel aes-x86_64 glue_helper gf128mul lrw ablk_helper aesni-intel libcrc32c xor zlib_deflate raid6_pq btrfs
Features:       acpi dm intel_microcode block usb lvm2 luks btrfs resume.userspace resume.kernel

Kernel image:   /boot/vmlinuz-3.13.6-1.g4727218-desktop
Initrd image:   /boot/initrd-3.13.6-1.g4727218-desktop
KMS drivers:     nvidia
Root device:    /dev/vg0/lvsuse (mounted on / as ext4)
Resume device:  /dev/vg0/lvswap
enabling LUKS support for /dev/disk/by-id/ata-Corsair_Force_GT_114882050000098800C7-part2 (cr_sda2)
Microcode: Adding Intel microcode 06-2a-07
Kernel Modules: thermal_sys thermal processor fan dm-mod dm-crypt dm-log dm-region-hash dm-mirror dm-snapshot scsi_dh scsi_dh_hp_sw scsi_dh_alua scsi_dh_rdac scsi_dh_emc drm nvidia xhci-hcd hid-logitech-dj hid-holtek-kbd hid-lenovo-tpkbd hid-ortek hid-roccat hid-roccat-common hid-roccat-arvo hid-roccat-isku hid-samsung ohci-pci linear arc4 sha256_generic cryptd crct10dif-pclmul crc32-pclmul crc32c-intel ghash-clmulni-intel aes-x86_64 glue_helper gf128mul lrw ablk_helper aesni-intel libcrc32c xor raid6_pq btrfs
Features:       acpi dm intel_microcode kms block usb lvm2 luks btrfs resume.userspace resume.kernel

Kernel image:   /boot/vmlinuz-3.13.6-2.g0509ce5-desktop
Initrd image:   /boot/initrd-3.13.6-2.g0509ce5-desktop
KMS drivers:     nvidia
Root device:    /dev/vg0/lvsuse (mounted on / as ext4)
Resume device:  /dev/vg0/lvswap
enabling LUKS support for /dev/disk/by-id/ata-Corsair_Force_GT_114882050000098800C7-part2 (cr_sda2)
Microcode: Adding Intel microcode 06-2a-07
Kernel Modules: thermal_sys thermal processor fan dm-mod dm-crypt dm-log dm-region-hash dm-mirror dm-snapshot scsi_dh scsi_dh_hp_sw scsi_dh_alua scsi_dh_rdac scsi_dh_emc drm nvidia xhci-hcd hid-logitech-dj hid-holtek-kbd hid-lenovo-tpkbd hid-ortek hid-roccat hid-roccat-common hid-roccat-arvo hid-roccat-isku hid-samsung ohci-pci linear arc4 sha256_generic cryptd crct10dif-pclmul crc32-pclmul crc32c-intel ghash-clmulni-intel aes-x86_64 glue_helper gf128mul lrw ablk_helper aesni-intel libcrc32c xor raid6_pq btrfs
Features:       acpi dm intel_microcode kms block usb lvm2 luks btrfs resume.userspace resume.kernel

real    0m11.429s
user    0m20.990s
sys     0m2.399s
