### PR TITLE
don't wait for sda1 to appear as dm device

### DIFF
--- a/mkinitrd.changes
+++ b/mkinitrd.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 29 20:02:33 UTC 2018 - mwilck@suse.com
+
+- check_for_device: match only udev symlinks by major number
+  (bnc#726313)
+
+-------------------------------------------------------------------
 Fri Mar  3 10:24:02 CET 2017 - dmolkentin@suse.com
 
 - Prevent false error messages from setup-network.sh (bnc#1027452).

--- a/scripts/boot-devfunctions.sh
+++ b/scripts/boot-devfunctions.sh
@@ -59,6 +59,11 @@ check_for_device() {
     else
         dm_major=
     fi
+    # Only do major number matches for udev-managed symlinks
+    case "$root" in
+	*/disk/by-id/*|*/disk/by-uuid/*|*/disk/by-label/*|*/mapper/*) ;;
+	*) dm_major= ;;
+    esac
     if [ -n "$root" ]; then
         echo -n "Waiting for device $root to appear: "
         while [ $timeout -gt 0 ]; do


### PR DESCRIPTION
This fixes [bnc#726313](https://bugzilla.novell.com/show_bug.cgi?id=726313), see discussion there.

Btw, as I'm now bugowner for mkinitrd, I'd appreciate write permissions to this repo.
