### PR TITLE
Dereference symlinks when copying binaries (bsc#1118723).

### DIFF
--- a/mkinitrd.changes
+++ b/mkinitrd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Dec 11 16:45:36 UTC 2018 - Michal Suchanek <msuchanek@suse.de>
+
+- Dereference symlinks when copying binaries (bsc#1118723)
+
+-------------------------------------------------------------------
 Wed Nov  7 20:25:20 UTC 2018 - Martin Wilck <mwilck@suse.com>
 
 - make mkinitrd content private

--- a/scripts/setup-prepare.sh
+++ b/scripts/setup-prepare.sh
@@ -24,7 +24,7 @@
 
 # Install a binary file
 cp_bin() {
-    cp -a "$@" \
+    cp -aL "$@" \
     || exit_code=1
 
     # Remember the binaries installed. We need the list for checking


### PR DESCRIPTION
Fix error udevd-work[3889]: exec of program '/bin/grep' failed

Signed-off-by: Michal Suchanek <msuchanek@suse.de>